### PR TITLE
Add support for parsing tables with missing cells

### DIFF
--- a/core/src/commonMain/kotlin/com/boswelja/markdown/generator/MarkdownNodeGenerator.kt
+++ b/core/src/commonMain/kotlin/com/boswelja/markdown/generator/MarkdownNodeGenerator.kt
@@ -77,11 +77,13 @@ internal class MarkdownNodeGenerator(
             .filter { it.type == GFMElementTypes.ROW }
         val columns = headers.mapIndexed { index: Int, headerNode: ASTNode ->
             val columnCellNodes = bodyNodes
-                .map { row -> row.children.filter { it.type == GFMTokenTypes.CELL }[index] }
+                .map { row -> row.children.filter { it.type == GFMTokenTypes.CELL }.getOrNull(index) }
             MarkdownTable.Column(
                 header = parseParagraphNode(headerNode),
                 alignment = MarkdownTable.Alignment.LEFT,
-                cells = columnCellNodes.map { parseParagraphNode(it) }
+                cells = columnCellNodes.map { node ->
+                    node?.let { parseParagraphNode(it) } ?: MarkdownParagraph(listOf(MarkdownWhitespace))
+                }
             )
         }
         return MarkdownTable(columns)

--- a/core/src/commonTest/kotlin/com/nasdroid/core/markdown/MarkdownNodeGeneratorTest.kt
+++ b/core/src/commonTest/kotlin/com/nasdroid/core/markdown/MarkdownNodeGeneratorTest.kt
@@ -224,6 +224,31 @@ class MarkdownNodeGeneratorTest {
                     markdownParagraph(markdownText("baz")),
                     MarkdownTable.Alignment.CENTER,
                 )
+            ),
+            """
+                | foo | bar | baz |
+                | --- | --- | :--- |
+                | cell1 | cell2 |
+                | cell3 | cell4 | cell5 |
+            """.trimIndent() to markdownTable(
+                markdownTableColumn(
+                    markdownParagraph(markdownText("foo")),
+                    MarkdownTable.Alignment.LEFT,
+                    markdownParagraph(markdownText("cell1")),
+                    markdownParagraph(markdownText("cell3"))
+                ),
+                markdownTableColumn(
+                    markdownParagraph(markdownText("bar")),
+                    MarkdownTable.Alignment.RIGHT,
+                    markdownParagraph(markdownText("cell2")),
+                    markdownParagraph(markdownText("cell4"))
+                ),
+                markdownTableColumn(
+                    markdownParagraph(markdownText("baz")),
+                    MarkdownTable.Alignment.CENTER,
+                    markdownParagraph(MarkdownWhitespace),
+                    markdownParagraph(markdownText("cell5"))
+                )
             )
         )
 


### PR DESCRIPTION
Previously, this would've been an exception. Now it is rendered as an empty cell in the table.

![image](https://github.com/boswelja/compose-markdown/assets/15526339/09770255-71e7-47a0-9159-71672a1004f6)
