### PR TITLE
Add support for clickable links

### DIFF
--- a/core/src/commonMain/kotlin/com/boswelja/markdown/MarkdownDocument.kt
+++ b/core/src/commonMain/kotlin/com/boswelja/markdown/MarkdownDocument.kt
@@ -50,6 +50,7 @@ public fun MarkdownDocument(
     codeBlockStyle: CodeBlockStyle,
     ruleStyle: RuleStyle,
     tableStyle: TableStyle,
+    onLinkClick: (String) -> Unit,
     modifier: Modifier = Modifier,
     sectionSpacing: Dp = textStyles.textStyle.fontSize.toDp()
 ) {
@@ -70,7 +71,8 @@ public fun MarkdownDocument(
                 blockQuoteStyle = blockQuoteStyle,
                 codeBlockStyle = codeBlockStyle,
                 ruleStyle = ruleStyle,
-                tableStyle = tableStyle
+                tableStyle = tableStyle,
+                onLinkClick = onLinkClick,
             )
         }
     }
@@ -92,6 +94,7 @@ internal fun MarkdownNode(
     codeBlockStyle: CodeBlockStyle,
     ruleStyle: RuleStyle,
     tableStyle: TableStyle,
+    onLinkClick: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     when (node) {
@@ -103,6 +106,7 @@ internal fun MarkdownNode(
             codeBlockStyle = codeBlockStyle,
             ruleStyle = ruleStyle,
             tableStyle = tableStyle,
+            onLinkClick = onLinkClick,
             modifier = modifier,
         )
         is MarkdownCodeBlock -> MarkdownCodeBlock(
@@ -125,12 +129,14 @@ internal fun MarkdownNode(
             codeBlockStyle = codeBlockStyle,
             ruleStyle = ruleStyle,
             tableStyle = tableStyle,
+            onLinkClick = onLinkClick,
             modifier = modifier
         )
         is MarkdownParagraph -> MarkdownParagraph(
             paragraph = node,
             textStyle = textStyles.textStyle,
             textStyleModifiers = textStyleModifiers,
+            onLinkClick = onLinkClick,
             modifier = modifier
         )
         MarkdownRule -> MarkdownRule(
@@ -143,6 +149,7 @@ internal fun MarkdownNode(
             textStyle = textStyles.textStyle,
             textStyleModifiers = textStyleModifiers,
             ruleStyle = ruleStyle,
+            onLinkClick = onLinkClick,
             modifier = modifier
         )
         is MarkdownHtmlBlock -> MarkdownHtmlBlock(
@@ -158,6 +165,7 @@ internal fun MarkdownNode(
             codeBlockStyle = codeBlockStyle,
             ruleStyle = ruleStyle,
             tableStyle = tableStyle,
+            onLinkClick = onLinkClick,
             modifier = modifier
         )
     }

--- a/core/src/commonMain/kotlin/com/boswelja/markdown/components/MarkdownBlockQuote.kt
+++ b/core/src/commonMain/kotlin/com/boswelja/markdown/components/MarkdownBlockQuote.kt
@@ -35,6 +35,7 @@ internal fun MarkdownBlockQuote(
     codeBlockStyle: CodeBlockStyle,
     ruleStyle: RuleStyle,
     tableStyle: TableStyle,
+    onLinkClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(
@@ -65,7 +66,8 @@ internal fun MarkdownBlockQuote(
                         blockQuoteStyle = style,
                         codeBlockStyle = codeBlockStyle,
                         ruleStyle = ruleStyle,
-                        tableStyle = tableStyle
+                        tableStyle = tableStyle,
+                        onLinkClick = onLinkClick
                     )
                 }
             }

--- a/core/src/commonMain/kotlin/com/boswelja/markdown/components/MarkdownList.kt
+++ b/core/src/commonMain/kotlin/com/boswelja/markdown/components/MarkdownList.kt
@@ -33,6 +33,7 @@ internal fun MarkdownOrderedList(
     codeBlockStyle: CodeBlockStyle,
     ruleStyle: RuleStyle,
     tableStyle: TableStyle,
+    onLinkClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier) {
@@ -54,7 +55,8 @@ internal fun MarkdownOrderedList(
                             blockQuoteStyle = blockQuoteStyle,
                             codeBlockStyle = codeBlockStyle,
                             ruleStyle = ruleStyle,
-                            tableStyle = tableStyle
+                            tableStyle = tableStyle,
+                            onLinkClick = onLinkClick
                         )
                     }
                 }
@@ -76,6 +78,7 @@ internal fun MarkdownUnorderedList(
     codeBlockStyle: CodeBlockStyle,
     ruleStyle: RuleStyle,
     tableStyle: TableStyle,
+    onLinkClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier) {
@@ -96,7 +99,8 @@ internal fun MarkdownUnorderedList(
                             blockQuoteStyle = blockQuoteStyle,
                             codeBlockStyle = codeBlockStyle,
                             ruleStyle = ruleStyle,
-                            tableStyle = tableStyle
+                            tableStyle = tableStyle,
+                            onLinkClick = onLinkClick
                         )
                     }
                 }

--- a/core/src/commonMain/kotlin/com/boswelja/markdown/components/MarkdownParagraph.kt
+++ b/core/src/commonMain/kotlin/com/boswelja/markdown/components/MarkdownParagraph.kt
@@ -1,9 +1,14 @@
 package com.boswelja.markdown.components
 
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.ExperimentalTextApi
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.sp
 import com.boswelja.markdown.generator.MarkdownParagraph
@@ -14,19 +19,35 @@ import com.boswelja.markdown.style.TextUnitSize
  * Displays a [MarkdownParagraph]. A paragraph is a group of "spans". Spans are stylized sections of
  * text, but can also include inline images and links.
  */
+@OptIn(ExperimentalTextApi::class)
 @Composable
 internal fun MarkdownParagraph(
     paragraph: MarkdownParagraph,
     textStyle: TextStyle,
     textStyleModifiers: TextStyleModifiers,
+    onLinkClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val (annotatedString, inlineContent) = remember(paragraph) {
         paragraph.children.buildTextWithContent(textStyle, textStyleModifiers, TextUnitSize(100.sp, 100.sp))
     }
+    val layoutResult = remember { mutableStateOf<TextLayoutResult?>(null) }
+    val pressIndicator = Modifier.pointerInput(onLinkClick, annotatedString) {
+        detectTapGestures { pos ->
+            layoutResult.value?.let { layoutResult ->
+                val offset = layoutResult.getOffsetForPosition(pos)
+                annotatedString.getUrlAnnotations(start = offset, end = offset).firstOrNull()?.let { annotation ->
+                    onLinkClick(annotation.item.url)
+                }
+            }
+        }
+    }
     BasicText(
         text = annotatedString,
-        modifier = modifier,
-        inlineContent = inlineContent
+        modifier = modifier.then(pressIndicator),
+        inlineContent = inlineContent,
+        onTextLayout = {
+            layoutResult.value = it
+        }
     )
 }

--- a/core/src/commonMain/kotlin/com/boswelja/markdown/components/MarkdownTable.kt
+++ b/core/src/commonMain/kotlin/com/boswelja/markdown/components/MarkdownTable.kt
@@ -22,6 +22,7 @@ internal fun MarkdownTable(
     textStyle: TextStyle,
     textStyleModifiers: TextStyleModifiers,
     ruleStyle: RuleStyle,
+    onLinkClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier) {
@@ -32,6 +33,7 @@ internal fun MarkdownTable(
                     paragraph = it.header,
                     textStyle = textStyle,
                     textStyleModifiers = textStyleModifiers,
+                    onLinkClick = onLinkClick,
                     modifier = Modifier.weight(1f).padding(style.cellPadding)
                 )
             }
@@ -44,6 +46,7 @@ internal fun MarkdownTable(
                         paragraph = it.cells[index],
                         textStyle = textStyle,
                         textStyleModifiers = textStyleModifiers,
+                        onLinkClick = onLinkClick,
                         modifier = Modifier.weight(1f).padding(style.cellPadding)
                     )
                 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,10 @@ coil = "3.0.0-alpha04"
 
 intellij-markdown = "0.6.1"
 
+androidx-browser = "1.7.0"
+
 [libraries]
+androidx-browser = { group = "androidx.browser", name = "browser", version.ref = "androidx-browser" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 coil-gif = { module = "io.coil-kt.coil3:coil-gif", version.ref = "coil" }
 coil-svg = { module = "io.coil-kt.coil3:coil-svg", version.ref = "coil" }

--- a/material3/build.gradle.kts
+++ b/material3/build.gradle.kts
@@ -58,6 +58,11 @@ kotlin {
                 implementation(compose.material3)
             }
         }
+        androidMain {
+            dependencies {
+                implementation(libs.androidx.browser)
+            }
+        }
     }
 }
 

--- a/material3/src/androidMain/kotlin/com/boswelja/markdown/material3/UrlLauncher.kt
+++ b/material3/src/androidMain/kotlin/com/boswelja/markdown/material3/UrlLauncher.kt
@@ -1,0 +1,24 @@
+package com.boswelja.markdown.material3
+
+import android.content.Context
+import android.net.Uri
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+
+@Composable
+public actual fun rememberUrlLauncher(): UrlLauncher {
+    val context = LocalContext.current
+    return remember(context) {
+        DefaultUrlLauncher(context)
+    }
+}
+
+internal class DefaultUrlLauncher(private val context: Context) : UrlLauncher {
+    override fun launchUrl(url: String) {
+        val intent = CustomTabsIntent.Builder()
+            .build()
+        intent.launchUrl(context, Uri.parse(url))
+    }
+}

--- a/material3/src/commonMain/kotlin/com/boswelja/markdown/material3/MarkdownDocument.kt
+++ b/material3/src/commonMain/kotlin/com/boswelja/markdown/material3/MarkdownDocument.kt
@@ -25,7 +25,8 @@ public fun MarkdownDocument(
     codeBlockStyle: CodeBlockStyle = m3CodeBlockStyle(),
     ruleStyle: RuleStyle = m3RuleStyle(),
     tableStyle: TableStyle = m3TableStyle(),
-    sectionSpacing: Dp = textStyles.textStyle.fontSize.toDp()
+    sectionSpacing: Dp = textStyles.textStyle.fontSize.toDp(),
+    urlLauncher: UrlLauncher = rememberUrlLauncher()
 ) {
     com.boswelja.markdown.MarkdownDocument(
         markdown = markdown,
@@ -35,6 +36,7 @@ public fun MarkdownDocument(
         codeBlockStyle = codeBlockStyle,
         ruleStyle = ruleStyle,
         tableStyle = tableStyle,
+        onLinkClick = { urlLauncher.launchUrl(it) },
         modifier = modifier,
         sectionSpacing = sectionSpacing
     )

--- a/material3/src/commonMain/kotlin/com/boswelja/markdown/material3/UrlLauncher.kt
+++ b/material3/src/commonMain/kotlin/com/boswelja/markdown/material3/UrlLauncher.kt
@@ -1,0 +1,24 @@
+package com.boswelja.markdown.material3
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+
+/**
+ * A contract that allows launching a URL, ideally from a Compose side-effect. See [launchUrl] for
+ * details.
+ */
+public interface UrlLauncher {
+
+    /**
+     * "Launches" the given URL in that platform-preferred manner. For example, on Android a Custom
+     * Tab might be launched.
+     */
+    public fun launchUrl(url: String)
+}
+
+/**
+ * Remembers the default URL launcher implementation.
+ */
+@Composable
+public expect fun rememberUrlLauncher(): UrlLauncher

--- a/material3/src/commonMain/kotlin/com/boswelja/markdown/material3/UrlLauncher.kt
+++ b/material3/src/commonMain/kotlin/com/boswelja/markdown/material3/UrlLauncher.kt
@@ -1,8 +1,6 @@
 package com.boswelja.markdown.material3
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import androidx.compose.ui.platform.LocalContext
 
 /**
  * A contract that allows launching a URL, ideally from a Compose side-effect. See [launchUrl] for


### PR DESCRIPTION
The core `MarkdownDocument` now supports handling user interactions with links! If you're using the Material 3 extension, this is all handled automatically for you.