### PR TITLE
Fix Markdown rule not showing with M3 styling

### DIFF
--- a/material3/src/commonMain/kotlin/com/boswelja/markdown/material3/Material3Ext.kt
+++ b/material3/src/commonMain/kotlin/com/boswelja/markdown/material3/Material3Ext.kt
@@ -2,6 +2,7 @@
 package com.boswelja.markdown.material3
 
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.material3.DividerDefaults
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -108,7 +109,7 @@ public fun m3CodeBlockStyle(
 public fun m3RuleStyle(
     color: Color = MaterialTheme.colorScheme.outlineVariant,
     shape: Shape = RectangleShape,
-    thickness: Dp = Dp.Hairline
+    thickness: Dp = DividerDefaults.Thickness
 ): RuleStyle {
     return RuleStyle(
         color = color,


### PR DESCRIPTION
Use `DividerDefaults.Thickness` instead of `Dp.Hairline` for the `m3RuleStyle`

Before | After
---|---
<img width="1080" height="2400" alt="Screenshot of sample app before divider change" src="https://github.com/user-attachments/assets/49d37743-a4b2-4ccf-986c-cb5ed42cb8fc" /> | <img width="1080" height="2400" alt="Screenshot of sample app after divider change" src="https://github.com/user-attachments/assets/6bc40d03-1d3f-43c8-bd31-6dba01a22222" />
